### PR TITLE
Dalecs iono fac equator

### DIFF
--- a/pyLTR/Physics/BS.py
+++ b/pyLTR/Physics/BS.py
@@ -1,4 +1,4 @@
-import pylab as p
+import numpy as np
 
 def bs_cart(rvecs, Jvecs, dvecs, observs):
    """
@@ -66,12 +66,12 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
    # check first required input parameter
    if not(len(rvecs) == 3):
       raise Exception('1st input must contain 3 items')
-   elif all([p.isscalar(rvecs[i]) for i in range(3)]):
+   elif all([np.isscalar(rvecs[i]) for i in range(3)]):
       # convert scalars to 0-rank arrays
-      rvecs[0] = p.array(rvecs[0])
-      rvecs[1] = p.array(rvecs[1])
-      rvecs[2] = p.array(rvecs[2])
-   elif not(all([type(rvecs[i]) is p.ndarray for i in range(3)])):
+      rvecs[0] = np.array(rvecs[0])
+      rvecs[1] = np.array(rvecs[1])
+      rvecs[2] = np.array(rvecs[2])
+   elif not(all([type(rvecs[i]) is np.ndarray for i in range(3)])):
       raise Exception('1st input must hold all scalars or all ndarrays')
    elif not(rvecs[0].shape == rvecs[1].shape and
             rvecs[0].shape == rvecs[2].shape):
@@ -89,12 +89,12 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
    # check second required input parameter
    if not(len(Jvecs) == 3):
       raise Exception('1st input must contain 3 items')
-   elif all([p.isscalar(Jvecs[i]) for i in range(3)]):
+   elif all([np.isscalar(Jvecs[i]) for i in range(3)]):
       # convert scalars to 0-rank arrays
-      Jvecs[0] = p.array(Jvecs[0])
-      Jvecs[1] = p.array(Jvecs[1])
-      Jvecs[2] = p.array(Jvecs[2])
-   elif not(all([type(Jvecs[i]) is p.ndarray for i in range(3)])):
+      Jvecs[0] = np.array(Jvecs[0])
+      Jvecs[1] = np.array(Jvecs[1])
+      Jvecs[2] = np.array(Jvecs[2])
+   elif not(all([type(Jvecs[i]) is np.ndarray for i in range(3)])):
       raise Exception('2nd input must hold all scalars or all ndarrays')
    elif not(Jvecs[0].shape == Jvecs[1].shape and
             Jvecs[0].shape == Jvecs[2].shape):
@@ -110,10 +110,10 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
 
 
    # check third required input parameter
-   if p.isscalar(dvecs):
+   if np.isscalar(dvecs):
       # convert scalar to 0-rank array
-      dvecs = p.array(dvecs)
-   elif not(type(dvecs) is p.ndarray):
+      dvecs = np.array(dvecs)
+   elif not(type(dvecs) is np.ndarray):
       raise Exception('3rd input must be a scalar or ndarray')
 
    if dvecs.dtype == object:
@@ -133,12 +133,12 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
    # check fourth required input parameter
    if not(len(observs) == 3):
       raise Exception('4th input must contain 3 items')
-   elif all([p.isscalar(observs[i]) for i in range(3)]):
+   elif all([np.isscalar(observs[i]) for i in range(3)]):
       # convert scalars to 0-rank arrays
-      observs[0] = p.array(observs[0])
-      observs[1] = p.array(observs[1])
-      observs[2] = p.array(observs[2])
-   elif not(all([type(observs[i]) is p.ndarray for i in range(3)])):
+      observs[0] = np.array(observs[0])
+      observs[1] = np.array(observs[1])
+      observs[2] = np.array(observs[2])
+   elif not(all([type(observs[i]) is np.ndarray for i in range(3)])):
       raise Exception('4th input must hold all scalars or all ndarrays')
    elif not(observs[0].shape == observs[1].shape and
             observs[0].shape == observs[2].shape):
@@ -158,13 +158,13 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
    # FIXME: weird things happen with concatenate() and object arrays; it would
    #        be much more readable if we could avoid this conditional block
    if rvecs[0].dtype == object:
-      xs = p.concatenate(rvecs[0].flatten())
-      ys = p.concatenate(rvecs[1].flatten())
-      zs = p.concatenate(rvecs[2].flatten())
-      Jxs = p.concatenate(Jvecs[0].flatten())
-      Jys = p.concatenate(Jvecs[1].flatten())
-      Jzs = p.concatenate(Jvecs[2].flatten())
-      dlavs = p.concatenate(dvecs.flatten())
+      xs = np.concatenate(rvecs[0].flatten())
+      ys = np.concatenate(rvecs[1].flatten())
+      zs = np.concatenate(rvecs[2].flatten())
+      Jxs = np.concatenate(Jvecs[0].flatten())
+      Jys = np.concatenate(Jvecs[1].flatten())
+      Jzs = np.concatenate(Jvecs[2].flatten())
+      dlavs = np.concatenate(dvecs.flatten())
    else:
       xs = rvecs[0].flatten()
       ys = rvecs[1].flatten()
@@ -181,15 +181,15 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
    obs_zs = observs[2].flatten()
 
    # get number of observatories
-   nobs = p.size(obs_xs)
+   nobs = np.size(obs_xs)
 
 
    # pre-allocate output arrays
    # NOTE: these are flattened for now, we will reshape them to match
    #       observs on exit
-   dBxs = p.zeros(obs_xs.shape)
-   dBys = p.zeros(obs_ys.shape)
-   dBzs = p.zeros(obs_zs.shape)
+   dBxs = np.zeros(obs_xs.shape)
+   dBys = np.zeros(obs_ys.shape)
+   dBzs = np.zeros(obs_zs.shape)
 
 
    #############################################################################
@@ -224,18 +224,18 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
    ## dys = obs_ys.reshape(1,obs_ys.size) - ys.reshape(ys.size,1)
    ## dzs = obs_zs.reshape(1,obs_zs.size) - zs.reshape(zs.size,1)
    ##
-   ## #dr3 = p.sqrt(dxs**2 + dys**2 + dzs**2)**3
-   ## dr = p.sqrt(dxs*dxs + dys*dys + dzs*dzs)
+   ## #dr3 = np.sqrt(dxs**2 + dys**2 + dzs**2)**3
+   ## dr = np.sqrt(dxs*dxs + dys*dys + dzs*dzs)
    ## dr3 = dr * dr * dr
    ##
    ##
-   ## dBxs = 1e-7 * p.nansum( (Jys.reshape(Jys.size,1) * dzs -
+   ## dBxs = 1e-7 * np.nansum( (Jys.reshape(Jys.size,1) * dzs -
    ##                          Jzs.reshape(Jzs.size,1) * dys) /
    ##                         dr3 * dlavs.reshape(dlavs.size,1), axis=0).flatten()
-   ## dBys = 1e-7 * p.nansum( (Jzs.reshape(Jzs.size,1) * dxs -
+   ## dBys = 1e-7 * np.nansum( (Jzs.reshape(Jzs.size,1) * dxs -
    ##                          Jxs.reshape(Jxs.size,1) * dzs) /
    ##                         dr3 * dlavs.reshape(dlavs.size,1), axis=0).flatten()
-   ## dBzs = 1e-7 * p.nansum( (Jxs.reshape(Jxs.size,1) * dys -
+   ## dBzs = 1e-7 * np.nansum( (Jxs.reshape(Jxs.size,1) * dys -
    ##                          Jys.reshape(Jys.size,1) * dxs) /
    ##                         dr3 * dlavs.reshape(dlavs.size,1), axis=0).flatten()
    ##
@@ -251,8 +251,8 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
       dzs = obs_zs[j] - zs
 
       # cube the magnitude of displacment vector
-      #dr3 = p.sqrt(dxs**2 + dys**2 + dzs**2)**3
-      dr = p.sqrt(dxs*dxs + dys*dys + dzs*dzs)
+      #dr3 = np.sqrt(dxs**2 + dys**2 + dzs**2)**3
+      dr = np.sqrt(dxs*dxs + dys*dys + dzs*dzs)
       dr3 = dr*dr*dr # avoiding powers leads to 2-3x speed improvement
 
       # integrate to get delta_B
@@ -260,9 +260,9 @@ def bs_cart(rvecs, Jvecs, dvecs, observs):
       #       to a flux density in units of Tesla. Given there is a 4*pi normalizing
       #       constant in the Biot-Savart relationsip, we can simply use 10^-7 to
       #       produce results in Tesla.
-      dBxs[j] = 1e-7 * p.nansum( (Jys * dzs - Jzs * dys) / dr3 * dlavs)
-      dBys[j] = 1e-7 * p.nansum( (Jzs * dxs - Jxs * dzs) / dr3 * dlavs)
-      dBzs[j] = 1e-7 * p.nansum( (Jxs * dys - Jys * dxs) / dr3 * dlavs)
+      dBxs[j] = 1e-7 * np.nansum( (Jys * dzs - Jzs * dys) / dr3 * dlavs)
+      dBys[j] = 1e-7 * np.nansum( (Jzs * dxs - Jxs * dzs) / dr3 * dlavs)
+      dBzs[j] = 1e-7 * np.nansum( (Jxs * dys - Jys * dxs) / dr3 * dlavs)
 
 
    return (dBxs.reshape(observs[0].shape),
@@ -348,12 +348,12 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    # check first required input parameter
    if not(len(rvecs) == 3):
       raise Exception('1st input must contain 3 items')
-   elif all([p.isscalar(rvecs[i]) for i in range(3)]):
+   elif all([np.isscalar(rvecs[i]) for i in range(3)]):
       # convert scalars to 0-rank arrays
-      rvecs[0] = p.array(rvecs[0])
-      rvecs[1] = p.array(rvecs[1])
-      rvecs[2] = p.array(rvecs[2])
-   elif not(all([type(rvecs[i]) is p.ndarray for i in range(3)])):
+      rvecs[0] = np.array(rvecs[0])
+      rvecs[1] = np.array(rvecs[1])
+      rvecs[2] = np.array(rvecs[2])
+   elif not(all([type(rvecs[i]) is np.ndarray for i in range(3)])):
       raise Exception('1st input must hold all scalars or all ndarrays')
    elif not(rvecs[0].shape == rvecs[1].shape and
             rvecs[0].shape == rvecs[2].shape):
@@ -370,12 +370,12 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    # check second required input parameter
    if not(len(Jvecs) == 3):
       raise Exception('1st input must contain 3 items')
-   elif all([p.isscalar(Jvecs[i]) for i in range(3)]):
+   elif all([np.isscalar(Jvecs[i]) for i in range(3)]):
       # convert scalars to 0-rank arrays
-      Jvecs[0] = p.array(Jvecs[0])
-      Jvecs[1] = p.array(Jvecs[1])
-      Jvecs[2] = p.array(Jvecs[2])
-   elif not(all([type(Jvecs[i]) is p.ndarray for i in range(3)])):
+      Jvecs[0] = np.array(Jvecs[0])
+      Jvecs[1] = np.array(Jvecs[1])
+      Jvecs[2] = np.array(Jvecs[2])
+   elif not(all([type(Jvecs[i]) is np.ndarray for i in range(3)])):
       raise Exception('2nd input must hold all scalars or all ndarrays')
    elif not(Jvecs[0].shape == Jvecs[1].shape and
             Jvecs[0].shape == Jvecs[2].shape):
@@ -391,10 +391,10 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
 
 
    # check third required input parameter
-   if p.isscalar(dvecs):
+   if np.isscalar(dvecs):
       # convert scalar to 0-rank array
-      dvecs = p.array(dvecs)
-   elif not(type(dvecs) is p.ndarray):
+      dvecs = np.array(dvecs)
+   elif not(type(dvecs) is np.ndarray):
       raise Exception('3rd input must be a scalar or ndarray')
 
    if dvecs.dtype == object:
@@ -414,12 +414,12 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    # check fourth required input parameter
    if not(len(observs) == 3):
       raise Exception('4th input must contain 3 items')
-   elif all([p.isscalar(observs[i]) for i in range(3)]):
+   elif all([np.isscalar(observs[i]) for i in range(3)]):
       # convert scalars to 0-rank arrays
-      observs[0] = p.array(observs[0])
-      observs[1] = p.array(observs[1])
-      observs[2] = p.array(observs[2])
-   elif not(all([type(observs[i]) is p.ndarray for i in range(3)])):
+      observs[0] = np.array(observs[0])
+      observs[1] = np.array(observs[1])
+      observs[2] = np.array(observs[2])
+   elif not(all([type(observs[i]) is np.ndarray for i in range(3)])):
       raise Exception('4th input must hold all scalars or all ndarrays')
    elif not(observs[0].shape == observs[1].shape and
             observs[0].shape == observs[2].shape):
@@ -441,13 +441,13 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    # FIXME: weird things happen with concatenate() and object arrays; it would
    #        be much more readable if we could avoid this conditional block
    if rvecs[0].dtype == object:
-      phis = p.concatenate(rvecs[0].flatten())
-      thetas = p.concatenate(rvecs[1].flatten())
-      rhos = p.concatenate(rvecs[2].flatten())
-      Jphis = p.concatenate(Jvecs[0].flatten())
-      Jthetas = p.concatenate(Jvecs[1].flatten())
-      Jrhos = p.concatenate(Jvecs[2].flatten())
-      dlavs = p.concatenate(dvecs.flatten())
+      phis = np.concatenate(rvecs[0].flatten())
+      thetas = np.concatenate(rvecs[1].flatten())
+      rhos = np.concatenate(rvecs[2].flatten())
+      Jphis = np.concatenate(Jvecs[0].flatten())
+      Jthetas = np.concatenate(Jvecs[1].flatten())
+      Jrhos = np.concatenate(Jvecs[2].flatten())
+      dlavs = np.concatenate(dvecs.flatten())
    else:
       phis = rvecs[0].flatten()
       thetas = rvecs[1].flatten()
@@ -464,7 +464,7 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    obs_rhos = observs[2].flatten()
 
    # get number of observatories
-   nobs = p.size(obs_phis)
+   nobs = np.size(obs_phis)
 
 
 
@@ -510,9 +510,9 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    ## # pre-allocate output arrays
    ## # NOTE: these are flattened for now, we will reshape them to match
    ## #       observs on exit
-   ## dBphis = p.zeros(obs_phis.shape)
-   ## dBthetas = p.zeros(obs_thetas.shape)
-   ## dBrhos = p.zeros(obs_rhos.shape)
+   ## dBphis = np.zeros(obs_phis.shape)
+   ## dBthetas = np.zeros(obs_thetas.shape)
+   ## dBrhos = np.zeros(obs_rhos.shape)
    ##
    ##
    ##
@@ -526,29 +526,29 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    ##    # NOTE: we don't actually create the full matrix, or multiply by it; this
    ##    # is probably somewhat inefficient, but it follows the algorithm described
    ##    # by K&R(1977) exactly...it probably doesn't lose too much efficiency.
-   ##    a11 = (p.sin(obs_thetas[j]) * p.sin(thetas) * p.cos(obs_phis[j] - phis) +
-   ##           p.cos(obs_thetas[j]) * p.cos(thetas))
-   ##    a12 = (p.sin(obs_thetas[j]) * p.cos(thetas) * p.cos(obs_phis[j] - phis) -
-   ##           p.cos(obs_thetas[j]) * p.sin(thetas))
-   ##    a13 =  p.sin(obs_thetas[j]) * p.sin(obs_phis[j] - phis)
-   ##    a21 = (p.cos(obs_thetas[j]) * p.sin(thetas) * p.cos(obs_phis[j] - phis) -
-   ##           p.sin(obs_thetas[j]) * p.cos(thetas))
-   ##    a22 = (p.cos(obs_thetas[j]) * p.cos(thetas) * p.cos(obs_phis[j] - phis) +
-   ##           p.sin(obs_thetas[j]) * p.sin(thetas))
-   ##    a23 =  p.cos(obs_thetas[j]) * p.sin(obs_phis[j] - phis)
-   ##    a31 = -p.sin(thetas) * p.sin(obs_phis[j] - phis)
-   ##    a32 = -p.cos(thetas) * p.sin(obs_phis[j] - phis)
-   ##    a33 = p.cos(obs_phis[j] - phis);
+   ##    a11 = (np.sin(obs_thetas[j]) * np.sin(thetas) * np.cos(obs_phis[j] - phis) +
+   ##           np.cos(obs_thetas[j]) * np.cos(thetas))
+   ##    a12 = (np.sin(obs_thetas[j]) * np.cos(thetas) * np.cos(obs_phis[j] - phis) -
+   ##           np.cos(obs_thetas[j]) * np.sin(thetas))
+   ##    a13 =  np.sin(obs_thetas[j]) * np.sin(obs_phis[j] - phis)
+   ##    a21 = (np.cos(obs_thetas[j]) * np.sin(thetas) * np.cos(obs_phis[j] - phis) -
+   ##           np.sin(obs_thetas[j]) * np.cos(thetas))
+   ##    a22 = (np.cos(obs_thetas[j]) * np.cos(thetas) * np.cos(obs_phis[j] - phis) +
+   ##           np.sin(obs_thetas[j]) * np.sin(thetas))
+   ##    a23 =  np.cos(obs_thetas[j]) * np.sin(obs_phis[j] - phis)
+   ##    a31 = -np.sin(thetas) * np.sin(obs_phis[j] - phis)
+   ##    a32 = -np.cos(thetas) * np.sin(obs_phis[j] - phis)
+   ##    a33 = np.cos(obs_phis[j] - phis);
    ##
    ##
    ##    # create rotation matrix elements k_{ij}
-   ##    invRmag = 1 / p.sqrt(rhos**2 + obs_rhos[j]**2 - 2 * rhos * obs_rhos[j] * a11)
+   ##    invRmag = 1 / np.sqrt(rhos**2 + obs_rhos[j]**2 - 2 * rhos * obs_rhos[j] * a11)
    ##
    ##    # if Rmag==zero, invRmag==Inf...assume magnetic field cancels within the
    ##    # volume, just like at the center of a wire with uniform current
-   ##    invRmag[p.isinf(invRmag)] = 0;
+   ##    invRmag[np.isinf(invRmag)] = 0;
    ##
-   ##    k11 = invRmag**3 * p.zeros(p.size(a11));
+   ##    k11 = invRmag**3 * np.zeros(np.size(a11));
    ##    k12 = invRmag**3 * rhos * a13;
    ##    k13 = invRmag**3 * -rhos * a12;
    ##    k21 = invRmag**3 * obs_rhos[j] * a31;
@@ -564,13 +564,13 @@ def bs_sphere(rvecs, Jvecs, dvecs, observs):
    ##    #       to a flux density in units of Tesla. Given there is a 4*pi normalizing
    ##    #       constant in the Biot-Savart relationsip, we can simply use 10^-7 to
    ##    #       produce results in Tesla.
-   ##    dBrhos[j]   = dBrhos[j] +   1e-7 * p.nansum((k11 * Jrhos +
+   ##    dBrhos[j]   = dBrhos[j] +   1e-7 * np.nansum((k11 * Jrhos +
    ##                                                 k12 * Jthetas +
    ##                                                 k13 * Jphis) * dlavs)
-   ##    dBthetas[j] = dBthetas[j] + 1e-7 * p.nansum((k21 * Jrhos +
+   ##    dBthetas[j] = dBthetas[j] + 1e-7 * np.nansum((k21 * Jrhos +
    ##                                                 k22 * Jthetas +
    ##                                                 k23 * Jphis) * dlavs)
-   ##    dBphis[j]   = dBphis[j] +   1e-7 * p.nansum((k31 * Jrhos +
+   ##    dBphis[j]   = dBphis[j] +   1e-7 * np.nansum((k31 * Jrhos +
    ##                                                 k32 * Jthetas +
    ##                                                 k33 * Jphis) * dlavs)
    ##
@@ -598,9 +598,9 @@ def _sp2cart_pos(r):
    """
    phis, thetas, rhos = r
 
-   xs = rhos * p.sin(thetas) * p.cos(phis)
-   ys = rhos * p.sin(thetas) * p.sin(phis)
-   zs = rhos * p.cos(thetas)
+   xs = rhos * np.sin(thetas) * np.cos(phis)
+   ys = rhos * np.sin(thetas) * np.sin(phis)
+   zs = rhos * np.cos(thetas)
 
    return (xs, ys, zs)
 
@@ -612,15 +612,15 @@ def _sp2cart_dir(v, r):
    dphis, dthetas, drhos = v
    phis, thetas, rhos = r
 
-   dxs = (p.sin(thetas) * p.cos(phis) * drhos +
-          p.cos(thetas) * p.cos(phis) * dthetas -
-          p.sin(phis) * dphis)
+   dxs = (np.sin(thetas) * np.cos(phis) * drhos +
+          np.cos(thetas) * np.cos(phis) * dthetas -
+          np.sin(phis) * dphis)
 
-   dys = (p.sin(thetas) * p.sin(phis) * drhos +
-          p.cos(thetas) * p.sin(phis) * dthetas +
-          p.cos(phis) * dphis)
+   dys = (np.sin(thetas) * np.sin(phis) * drhos +
+          np.cos(thetas) * np.sin(phis) * dthetas +
+          np.cos(phis) * dphis)
 
-   dzs = (p.cos(thetas) * drhos - p.sin(thetas) * dthetas)
+   dzs = (np.cos(thetas) * drhos - np.sin(thetas) * dthetas)
 
 
    return (dxs, dys, dzs)
@@ -633,17 +633,17 @@ def _cart2sp_pos(r):
    xs, ys, zs = r
 
    # use arctan2
-   phis = p.arctan2(ys, xs)
+   phis = np.arctan2(ys, xs)
 
    # first determine cylindrical radius, or else we won't be able to
    # get a reasonable theta if/when rsph is zero
-   rhos = p.sqrt(xs**2 + ys**2)
+   rhos = np.sqrt(xs**2 + ys**2)
 
    # calculate thetas
-   thetas = p.arctan2(rhos,zs)
+   thetas = np.arctan2(rhos,zs)
 
    # now, calculate spherical radius
-   rhos = p.sqrt(rhos**2 + zs**2)
+   rhos = np.sqrt(rhos**2 + zs**2)
 
 
    return (phis, thetas, rhos)
@@ -659,15 +659,15 @@ def _cart2sp_dir(v, r):
    # first, find position vectors in spherical coordinates
    (phis, thetas, rhos) = _cart2sp_pos((xs, ys, zs))
 
-   drhos = (p.sin(thetas) * p.cos(phis) * dxs +
-            p.sin(thetas) * p.sin(phis) * dys +
-            p.cos(thetas) * dzs)
+   drhos = (np.sin(thetas) * np.cos(phis) * dxs +
+            np.sin(thetas) * np.sin(phis) * dys +
+            np.cos(thetas) * dzs)
 
-   dthetas = (p.cos(thetas) * p.cos(phis) * dxs +
-              p.cos(thetas) * p.sin(phis) * dys -
-              p.sin(thetas) * dzs)
+   dthetas = (np.cos(thetas) * np.cos(phis) * dxs +
+              np.cos(thetas) * np.sin(phis) * dys -
+              np.sin(thetas) * dzs)
 
-   dphis = (p.cos(phis) * dys - p.sin(phis) * dxs)
+   dphis = (np.cos(phis) * dys - np.sin(phis) * dxs)
 
 
    return (dphis, dthetas, drhos)

--- a/pyLTR/Tools/deltaBTimeSeries.py
+++ b/pyLTR/Tools/deltaBTimeSeries.py
@@ -876,8 +876,8 @@ def extractQuantities(path='./', run='',
 
 
 
-              #if dTIEGCM:
-              if False:
+              if dTIEGCM:
+              #if False:
                   # retrieve TIEGCM height-integrated currents:convert to SM 
                   # coordinates, set thetas that overlap with MIX to zero, 
                   # generate DALECS, calculate deltaB
@@ -943,6 +943,7 @@ def extractQuantities(path='./', run='',
 
 
 
+              #if False:
               if dLFM:
                   
                   # finally, retrieve magnetospheric currents from LFM file,

--- a/pyLTR/Tools/deltaBTimeSeries_v2.py
+++ b/pyLTR/Tools/deltaBTimeSeries_v2.py
@@ -388,9 +388,6 @@ def extractQuantities(path='./', run='',
     print(( 'Extracting quantities for %d time steps.' % (index1-index0) ))
 
 
-
-
-
     # attempt to create corresponding TIEGCM data object; 
     # continue with warning if failure
     try:
@@ -412,8 +409,6 @@ def extractQuantities(path='./', run='',
     except:
         print("No or incompatible TIEGCM output found; continuing anyway...")
         dTIEGCM = None
-    
-    
     
     
     # attempt to create corresponding LFM data object;
@@ -474,89 +469,87 @@ def extractQuantities(path='./', run='',
     dBDown_mag = []
 
 
-
     #
-    # The biggest unnecessary CPU cost of everything below is re-calculating
-    # the DALECS each time step. If the coordinates of the ionospheric current
-    # segments don't change, then a single DALEC system can be calculated, and
-    # simply scaled by each new horizontal current distribution. So, calculate
-    # a DALECS for 1 amp in the south and 1 amp in the east directions, then 
-    # just multiply this by the actual current densities within the loop below.
-    # If the coordinate system is not SM (e.g., TIEGCM), a coordinate transform
-    # will be required at each time step, but this is much less CPU-intensive
-    # than re-calculating the DALECS each time. -EJR
+    # To lessen CPU cost in the loop below, we can pre-calculate DALECS that
+    # assume type1 and type2 loops are all fed by 1-Amp horizozntal currents
+    # in the ionosphere. Then it is merely a question of scaling these by
+    # the ionospheric currents read in at each time step.
     #
     DALECS = pyLTR.Physics.DALECS_v2
     
-    # Pre-compute MIX coordinates and DALECS for northern hemisphere
-    xN = dMIX.read('Grid X', timeRange[index0])
-    yN = dMIX.read('Grid Y', timeRange[index0])
-    thetaN = p.arctan2(yN,xN)
-    thetaN[thetaN<0] = thetaN[thetaN<0]+2*p.pi
-    rN = p.sqrt(xN**2+yN**2)
-    xN_dict = {'data':xN*6500e3,'name':'X','units':'m'}
-    yN_dict = {'data':yN*6500e3,'name':'Y','units':'m'}
-    longNdict = {'data':thetaN,'name':r'\phi','units':r'rad'}
-    colatNdict = {'data':n.arcsin(rN),'name':r'\theta','units':r'rad'}
-    
-    # Northern hemisphere
-#    phiN = longNdict['data']
-#    thetaN = colatNdict['data']
-#    rionN_min, rionN_max = pyLTR.Physics.DALECS._edgeGrid((phiN, thetaN))
-#    rionN_min.append(p.zeros(phiN.shape)+6500e3)
-#    rionN_max.append(p.zeros(phiN.shape)+p.Inf)
-#    
-#    # next, generate full DALECS for Northern ionospheric 1 Amp currents
-#    (rvN, JvN, dvN) = pyLTR.Physics.DALECS_v2.dalecs_sphere(
-#        [rionN_min[0], rionN_min[1], rionN_min[2]],
-#        [rionN_max[0], rionN_max[1], rionN_min[2]],
-#        (1 + np.zeros(rionN_min[0].shape), 1 + np.zeros(rionN_min[0].shape)),
-#        10, False)
-    dalecs_N = DALECS.dalecs((longNdict['data'], colatNdict['data']),
-                             ion_rho=6500e3)   
-    
-
-    # Pre-compute MIX coordinates and DALECS for southern hemisphere
-    xS = xN
-    yS = -yN
-    thetaS = p.arctan2(yS,xS)
-    thetaS[thetaS<0] = thetaS[thetaS<0]+2*p.pi
-    rS = p.sqrt(xS**2+yS**2)
-    xS_dict = {'data':xS*6500e3,'name':'X','units':'m'}
-    yS_dict = {'data':yS*6500e3,'name':'Y','units':'m'}
-    longSdict = {'data':thetaS,'name':r'\phi','units':r'rad'}
-    colatSdict = {'data':p.pi-n.arcsin(rS),'name':r'\theta','units':r'rad'}
-
-    # Southern hemisphere
-#    phiS = longNdict['data']
-#    thetaS = colatNdict['data']
-#    rionS_min, rionS_max = pyLTR.Physics.DALECS._edgeGrid((phiS, thetaS))
-#    rionS_min.append(p.zeros(phiS.shape)+6500e3)
-#    rionS_max.append(p.zeros(phiS.shape)+p.Inf)
-#    
-#    # next, generate full DALECS for Southern ionospheric 1 Amp currents
-#    (rvS, JvS, dvS) = pyLTR.Physics.DALECS_v2.dalecs_sphere(
-#        [rionS_min[0], rionS_min[1], rionS_min[2]],
-#        [rionS_max[0], rionS_max[1], rionS_min[2]],
-#        (1 + np.zeros(rionS_min[0].shape), 1 + np.zeros(rionS_min[0].shape)),
-#        10, False)
-    dalecs_S = DALECS.dalecs((longSdict['data'], colatSdict['data']),
-                             ion_rho=6500e3)
+    if dMIX:
+      # Pre-compute MIX coordinates and DALECS for northern hemisphere
+      xN = dMIX.read('Grid X', timeRange[index0])
+      yN = dMIX.read('Grid Y', timeRange[index0])
+      thetaN = p.arctan2(yN,xN)
+      thetaN[thetaN<0] = thetaN[thetaN<0]+2*p.pi
+      rN = p.sqrt(xN**2+yN**2)
+      xN_dict = {'data':xN*6500e3,'name':'X','units':'m'}
+      yN_dict = {'data':yN*6500e3,'name':'Y','units':'m'}
+      longNdict = {'data':thetaN,'name':r'\phi','units':r'rad'}
+      colatNdict = {'data':n.arcsin(rN),'name':r'\theta','units':r'rad'}
+      
+      # create 1-amp DALECS to be scaled inside the loop
+      # dalecs_N_all = DALECS.dalecs((longNdict['data'], colatNdict['data']),
+      #                               ion_rho=6500e3)
+      dalecs_N_ion = DALECS.dalecs((longNdict['data'], colatNdict['data']),
+                                    ion_rho=6500e3, fac=False, equator=False)
+      dalecs_N_fac = DALECS.dalecs((longNdict['data'], colatNdict['data']),
+                                    ion_rho=6500e3, iono=False)
+      dalecs_N_fac = dalecs_N_fac.trim(rho_max=2.5*6500e3)
+      
+      # convert _ion and _fac DALECS to Cartesian coordinates to avoid
+      # unnecessary conversions to/from spherical in the loop below
+      dalecs_N_ion.cartesian()
+      dalecs_N_fac.cartesian()
 
 
+      # Pre-compute MIX coordinates and DALECS for southern hemisphere
+      xS = xN
+      yS = -yN
+      thetaS = p.arctan2(yS,xS)
+      thetaS[thetaS<0] = thetaS[thetaS<0]+2*p.pi
+      rS = p.sqrt(xS**2+yS**2)
+      xS_dict = {'data':xS*6500e3,'name':'X','units':'m'}
+      yS_dict = {'data':yS*6500e3,'name':'Y','units':'m'}
+      longSdict = {'data':thetaS,'name':r'\phi','units':r'rad'}
+      colatSdict = {'data':p.pi-n.arcsin(rS),'name':r'\theta','units':r'rad'}
+
+      # create 1-amp DALECS to be scaled inside the loop
+      # dalecs_S_all = DALECS.dalecs((longSdict['data'], colatSdict['data']),
+      #                               ion_rho=6500e3)
+      dalecs_S_ion = DALECS.dalecs((longSdict['data'], colatSdict['data']),
+                                    ion_rho=6500e3, fac=False, equator=False)
+      dalecs_S_fac = DALECS.dalecs((longSdict['data'], colatSdict['data']),
+                                    ion_rho=6500e3, iono=False)
+      dalecs_S_fac = dalecs_S_fac.trim(rho_max=2.5*6500e3)
+
+      # convert _ion and _fac DALECS to Cartesian coordinates to avoid
+      # unnecessary conversions to/from spherical in the loop below
+      dalecs_S_ion.cartesian()
+      dalecs_S_fac.cartesian()
 
 
     if dTIEGCM:
-        # TIEGCM coordinates are magnetic latitude and longitude. They will need
-        # to be tranformed into sun-fixed SM coordinates below, but at the least,
-        # we can extract them once here. Convert to colatitude and polar angles,
-        # from degrees into radians, and turn into meshgrids for later use
-        theta_TIE_mag, phi_TIE_mag = p.meshgrid(
-            (90 - dTIEGCM.read('mlat', timeRange[index0])) * p.pi/180.,
-            dTIEGCM.read('mlon', timeRange[index0]) * p.pi/180.)
-        dalecs_T = DALECS.dalecs((phi_TIE_mag, theta_TIE_mag),
-                                 ion_rho=6500e3)
-
+      # TIEGCM coordinates are magnetic latitude and longitude. They will need
+      # to be tranformed into sun-fixed SM coordinates below, but at the least,
+      # we can extract them once here. Convert to colatitude and polar angles,
+      # from degrees into radians, and turn into meshgrids for later use
+      theta_TIE_geomag, phi_TIE_geomag = p.meshgrid(
+         (90 - dTIEGCM.read('mlat', timeRange[index0])) * p.pi/180.,
+         dTIEGCM.read('mlon', timeRange[index0]) * p.pi/180.)
+      
+      # dalecs_T_all = DALECS.dalecs((phi_TIE_geomag, theta_TIE_geomag),
+      #                               ion_rho=6500e3)
+      dalecs_T_ion = DALECS.dalecs((phi_TIE_geomag, theta_TIE_geomag),
+                                    ion_rho=6500e3, fac=False, equator=False)
+      dalecs_T_fac = DALECS.dalecs((phi_TIE_geomag, theta_TIE_geomag),
+                                    ion_rho=6500e3, iono=False)
+      dalecs_T_fac = dalecs_T_fac.trim(rho_max=2.5*6500e3)
+   
+      # convert to Cartesian coordinates
+      dalecs_T_ion.cartesian()
+      dalecs_T_fac.cartesian()
     
     
     if dLFM:
@@ -602,13 +595,13 @@ def extractQuantities(path='./', run='',
               obs_phi_geo = obs_phi
               obs_theta_geo = obs_theta
               obs_rho_geo = obs_rho
-              x,y,z = pyLTR.transform.SPHtoCAR(obs_phi,obs_theta,obs_rho)
-              x,y,z = pyLTR.transform.GEOtoSM(x,y,z,time)
-              obs_phi,obs_theta,obs_rho = pyLTR.transform.CARtoSPH(x,y,z)
+              x, y, z = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho)
+              obs_x, obs_y, obs_z = pyLTR.transform.GEOtoSM(x, y, z, time)
+              obs_phi, obs_theta, obs_rho = pyLTR.transform.CARtoSPH(obs_x, obs_y, obs_z)
            else:
-              x,y,z = pyLTR.transform.SPHtoCAR(obs_phi,obs_theta,obs_rho)
-              x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-              obs_phi_geo,obs_theta_geo,obs_rho_geo = pyLTR.transform.CARtoSPH(x,y,z)
+              obs_x, obs_y, obs_z = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho)
+              x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+              obs_phi_geo, obs_theta_geo, obs_rho_geo = pyLTR.transform.CARtoSPH(x, y, z)
 
 
            # this try/except block is designed to read pre-computed binary files
@@ -777,139 +770,37 @@ def extractQuantities(path='./', run='',
               
               # Calculate LFM's DALECS current segments
               if dMIX:
-              
-#                  # start by generating min/max bounds of ionosphere segments
-#
-#                  # Northern hemisphere
-#                  phiN = phiN_dict['data']
-#                  thetaN = thetaN_dict['data']
-#                  rionN_min, rionN_max = pyLTR.Physics.DALECS._edgeGrid((phiN,thetaN))
-#                  rionN_min.append(p.zeros(phiN.shape)+6500e3)
-#                  rionN_max.append(p.zeros(phiN.shape)+p.Inf)
-#
-#                  # Southern hemisphere
-#                  phiS = phiS_dict['data']
-#                  thetaS = thetaS_dict['data']
-#                  rionS_min, rionS_max = pyLTR.Physics.DALECS._edgeGrid((phiS,thetaS))
-#                  rionS_min.append(p.zeros(phiS.shape)+6500e3)
-#                  rionS_max.append(p.zeros(phiS.shape)+p.Inf)
-#                  
-#                  
-#                  
-#                  FIXME - it is not possible to simply scale Jv by the horizontal
-#                          currents, since I went and combined type1 and type1
-#                          Bostrom loops into one "object"...it really is best
-#                          to just re-do DALECS.py to define a DALECS class, which 
-#                          will contain the type1 and type2 loops, and will have
-#                          member functions to scale these properly.
-#                  (rvN_ion,
-#                   JvN_ion,
-#                   dvN_ion) = pyLTR.Physics.DALECS_v2._trim_phi_theta_rho(
-#                      rvN, JvN, dvN,
-#                      rho_min = ,
-#                      rho_max = )
-#                  
-#                  
-#
-#                  # next, generate DALECS for Northern ionospheric currents only
-#                  (rvN_ion,
-#                   JvN_ion,
-#                   dvN_ion) = pyLTR.Physics.DALECS.dalecs_sphere([rionN_min[0],rionN_min[1],rionN_min[2]],
-#                                                               [rionN_max[0],rionN_max[1],rionN_min[2]],
-#                                                               (JphiN_dict['data']/1e6,
-#                                                                JthetaN_dict['data']/1e6),
-#                                                               10, False)
-#
-#                  # next, generate DALECS for Northern hemisphere inside LFM inner boundary
-#                  (rvN_IBin,
-#                   JvN_IBin,
-#                   dvN_IBin) = pyLTR.Physics.DALECS.dalecs_sphere([rionN_min[0],rionN_min[1],rionN_min[2]],
-#                                                               [rionN_max[0],rionN_max[1],2.5*rionN_min[2]],
-#                                                               (JphiN_dict['data']/1e6,
-#                                                                JthetaN_dict['data']/1e6),
-#                                                               10, False)
-#
-#                  # do NOT attempt to generate DALECS for FACs alone...this isn't possible
-#                  # with existing code; However, the deltaB from FACs is the difference
-#                  # between deltaBs calculated from the two DALECS above
-#
-#                  """
-#                  # generate DALECS for Northern Hemisphere outside LFM inner boundary
-#                  # (this is serving as a proxy for magnetosphere currents for now)
-#                  (rvN_mag,
-#                   JvN_mag,
-#                   dvN_mag) = pyLTR.Physics.DALECS.dalecs_sphere([rionN_min[0],rionN_min[1],2.5*rionN_min[2]],
-#                                                              [rionN_max[0],rionN_max[1],rionN_min[2]],
-#                                                              (JphiN_dict['data']/1e6,
-#                                                               JthetaN_dict['data']/1e6),
-#                                                              10, False)
-#                  """
-#
-#                  # next, generate DALECS for Southern ionospheric currents only
-#                  (rvS_ion,
-#                   JvS_ion,
-#                   dvS_ion) = pyLTR.Physics.DALECS.dalecs_sphere([rionS_min[0],rionS_min[1],rionS_min[2]],
-#                                                              [rionS_max[0],rionS_max[1],rionS_min[2]],
-#                                                              (JphiS_dict['data']/1e6,
-#                                                               JthetaS_dict['data']/1e6),
-#                                                              10, False)
-#
-#                  # next, generate DALECS for Southern hemisphere inside LFM inner boundary
-#                  (rvS_IBin,
-#                   JvS_IBin,
-#                   dvS_IBin) = pyLTR.Physics.DALECS.dalecs_sphere([rionS_min[0],rionS_min[1],rionS_min[2]],
-#                                                               [rionS_max[0],rionS_max[1],2.5*rionS_min[2]],
-#                                                               (JphiS_dict['data']/1e6,
-#                                                                JthetaS_dict['data']/1e6),
-#                                                               10, False)
-#
-#                  # do NOT attempt to generate DALECS for FACs alone...this isn't possible
-#                  # with existing code; However, the deltaB from FACs is the difference
-#                  # between deltaBs calculated from the two DALECS above
-#
-#                  """
-#                  # generate DALECS for Southern Hemisphere outside LFM inner boundary
-#                  # (this is serving as a proxy for magnetosphere currents for now)
-#                  (rvS_mag,
-#                   JvS_mag,
-#                   dvS_mag) = pyLTR.Physics.DALECS.dalecs_sphere([rionS_min[0],rionS_min[1],2.5*rionS_min[2]],
-#                                                              [rionS_max[0],rionS_max[1],rionS_min[2]],
-#                                                              (JphiS_dict['data']/1e6,
-#                                                               JthetaS_dict['data']/1e6),
-#                                                              10, False)
-#                  """
-                  
-                  
-                  
-                  # generate Northern hemisphere DALECS (horizontal and FAC)
-                  dalecs_N_t = dalecs_N.scale((JphiN_dict['data']/1e6, 
-                                               JthetaN_dict['data']/1e6))
-                  dalecs_N_ion = dalecs_N_t.trim(rho_min=6500e3, rho_max=6500e3)
-                  rvN_ion = dalecs_N_ion.rvecs
-                  JvN_ion = dalecs_N_ion.Jvecs
-                  dvN_ion = dalecs_N_ion.dvecs
-                  
-                  dalecs_N_fac = dalecs_N_t.trim(rho_min=p.nextafter(6500e3, p.inf),
-                                                 rho_max=2.5*6500e3)
-                  rvN_fac = dalecs_N_fac.rvecs
-                  JvN_fac = dalecs_N_fac.Jvecs
-                  dvN_fac = dalecs_N_fac.dvecs
-                  
-                  
-                  # generate Southern hemisphere DALECS (horizontal and FAC)
-                  dalecs_S_t = dalecs_S.scale((JphiS_dict['data']/1e6, 
-                                               JthetaS_dict['data']/1e6))
-                  dalecs_S_ion = dalecs_S_t.trim(rho_min=6500e3, rho_max=6500e3)
-                  rvS_ion = dalecs_S_ion.rvecs
-                  JvS_ion = dalecs_S_ion.Jvecs
-                  dvS_ion = dalecs_S_ion.dvecs
-                  
-                  dalecs_S_fac = dalecs_S_t.trim(rho_min=p.nextafter(6500e3, p.inf),
-                                                 rho_max=2.5*6500e3)
-                  rvS_fac = dalecs_S_fac.rvecs
-                  JvS_fac = dalecs_S_fac.Jvecs
-                  dvS_fac = dalecs_S_fac.dvecs
+                                
+                  # generate Northern MIX DALECS (horizontal currents and FAC)
+                  dalecs_N_ion_tmp = dalecs_N_ion.scale(
+                     (JphiN_dict['data']/1e6, JthetaN_dict['data']/1e6)
+                  )
+                  rvN_ion = dalecs_N_ion_tmp.rvecs
+                  JvN_ion = dalecs_N_ion_tmp.Jvecs
+                  dvN_ion = dalecs_N_ion_tmp.dvecs
 
+                  dalecs_N_fac_tmp = dalecs_N_fac.scale(
+                     (JphiN_dict['data']/1e6, JthetaN_dict['data']/1e6)
+                  )
+                  rvN_fac = dalecs_N_fac_tmp.rvecs
+                  JvN_fac = dalecs_N_fac_tmp.Jvecs
+                  dvN_fac = dalecs_N_fac_tmp.dvecs
+                                    
+                  
+                  # generate Southern MIX DALECS (horizontal currents and FAC)
+                  dalecs_S_ion_tmp = dalecs_S_ion.scale(
+                     (JphiS_dict['data']/1e6, JthetaS_dict['data']/1e6)
+                  )
+                  rvS_ion = dalecs_S_ion_tmp.rvecs
+                  JvS_ion = dalecs_S_ion_tmp.Jvecs
+                  dvS_ion = dalecs_S_ion_tmp.dvecs
+
+                  dalecs_S_fac_tmp = dalecs_S_fac.scale(
+                     (JphiS_dict['data']/1e6, JthetaS_dict['data']/1e6)
+                  )
+                  rvS_fac = dalecs_S_fac_tmp.rvecs
+                  JvS_fac = dalecs_S_fac_tmp.Jvecs
+                  dvS_fac = dalecs_S_fac_tmp.dvecs
 
 
                   #
@@ -917,247 +808,160 @@ def extractQuantities(path='./', run='',
                   #
 
                   # deltaB for Northern ionospheric currents
-                  (dBphiN_ion,
-                   dBthetaN_ion,
-                   dBrhoN_ion) = pyLTR.Physics.BS.bs_sphere(rvN_ion,
-                                                            JvN_ion,
-                                                            dvN_ion,
-                                                            (obs_phi,obs_theta,obs_rho))
-#                  # deltaB for currents inside IB
-#                  (dBphiN_IBin,
-#                   dBthetaN_IBin,
-#                   dBrhoN_IBin) = pyLTR.Physics.BS.bs_sphere(rvN_IBin,
-#                                                            JvN_IBin,
-#                                                            dvN_IBin,
-#                                                            (obs_phi,obs_theta,obs_rho))
-#                  # difference between dB*_IBin and dB*_ion is the FAC inside IB
-#                  dBphiN_fac = dBphiN_IBin - dBphiN_ion
-#                  dBthetaN_fac = dBthetaN_IBin - dBthetaN_ion
-#                  dBrhoN_fac = dBrhoN_IBin - dBrhoN_ion
-                  
-                  # deltaB for Northern FACs
-                  (dBphiN_fac,
-                   dBthetaN_fac,
-                   dBrhoN_fac) = pyLTR.Physics.BS.bs_sphere(rvN_fac,
-                                                            JvN_fac,
-                                                            dvN_fac,
-                                                            (obs_phi,obs_theta,obs_rho))
-
-                  
-
+                  (dBxN_ion,
+                   dByN_ion,
+                   dBzN_ion) = DALECS.bs_cart(rvN_ion,
+                                              JvN_ion,
+                                              dvN_ion,
+                                              (obs_x,obs_y,obs_z))
+                 
+                  # # deltaB for Northern FACs
+                  (dBxN_fac,
+                   dByN_fac,
+                   dBzN_fac) = DALECS.bs_cart(rvN_fac,
+                                              JvN_fac,
+                                              dvN_fac,
+                                              (obs_x,obs_y,obs_z))
+                 
                   # deltaB for Southern ionospheric currents
-                  (dBphiS_ion,
-                   dBthetaS_ion,
-                   dBrhoS_ion) = pyLTR.Physics.BS.bs_sphere(rvS_ion,
-                                                            JvS_ion,
-                                                            dvS_ion,
-                                                            (obs_phi,obs_theta,obs_rho))
-#                  # deltaB for Southern DALECS currents inside IB
-#                  (dBphiS_IBin,
-#                   dBthetaS_IBin,
-#                   dBrhoS_IBin) = pyLTR.Physics.BS.bs_sphere(rvS_IBin,
-#                                                            JvS_IBin,
-#                                                            dvS_IBin,
-#                                                            (obs_phi,obs_theta,obs_rho))
-#                  # difference between dB*_IBin and dB*_ion is the FAC inside IB
-#                  dBphiS_fac = dBphiS_IBin - dBphiS_ion
-#                  dBthetaS_fac = dBthetaS_IBin - dBthetaS_ion
-#                  dBrhoS_fac = dBrhoS_IBin - dBrhoS_ion
+                  (dBxS_ion,
+                   dByS_ion,
+                   dBzS_ion) = DALECS.bs_cart(rvS_ion,
+                                              JvS_ion,
+                                              dvS_ion,
+                                              (obs_x,obs_y,obs_z))
                   
                   # deltaB for Southern FACs
-                  (dBphiS_fac,
-                   dBthetaS_fac,
-                   dBrhoS_fac) = pyLTR.Physics.BS.bs_sphere(rvS_fac,
-                                                            JvS_fac,
-                                                            dvS_fac,
-                                                            (obs_phi,obs_theta,obs_rho))
-
-
+                  (dBxS_fac,
+                   dByS_fac,
+                   dBzS_fac) = DALECS.bs_cart(rvS_fac,
+                                              JvS_fac,
+                                              dvS_fac,
+                                              (obs_x,obs_y,obs_z))
 
               else:
 
-                  # set dBs to zero if no MIX data is available
-                  dBphiN_ion = p.zeros(p.array(obs_phi).shape)
-                  dBthetaN_ion = p.zeros(p.array(obs_theta).shape)
-                  dBrhoN_ion = p.zeros(p.array(obs_rho).shape)
-                  dBphiN_fac = p.zeros(p.array(obs_phi).shape)
-                  dBthetaN_fac = p.zeros(p.array(obs_theta).shape)
-                  dBrhoN_fac = p.zeros(p.array(obs_rho).shape)
+                  # # set dBs to zero if no MIX data is available
+                  dBxN_ion = p.zeros(p.array(obs_x).shape)
+                  dByN_ion = p.zeros(p.array(obs_y).shape)
+                  dBzN_ion = p.zeros(p.array(obs_z).shape)
+                  dBxN_fac = p.zeros(p.array(obs_x).shape)
+                  dByN_fac = p.zeros(p.array(obs_y).shape)
+                  dBzN_fac = p.zeros(p.array(obs_z).shape)
 
-                  dBphiS_ion = p.zeros(p.array(obs_phi).shape)
-                  dBthetaS_ion = p.zeros(p.array(obs_theta).shape)
-                  dBrhoS_ion = p.zeros(p.array(obs_rho).shape)
-                  dBphiS_fac = p.zeros(p.array(obs_phi).shape)
-                  dBthetaS_fac = p.zeros(p.array(obs_theta).shape)
-                  dBrhoS_fac = p.zeros(p.array(obs_rho).shape)
+                  dBxS_ion = p.zeros(p.array(obs_x).shape)
+                  dByS_ion = p.zeros(p.array(obs_y).shape)
+                  dBzS_ion = p.zeros(p.array(obs_z).shape)
+                  dBxS_fac = p.zeros(p.array(obs_x).shape)
+                  dByS_fac = p.zeros(p.array(obs_y).shape)
+                  dBzS_fac = p.zeros(p.array(obs_z).shape)
 
 
 
-              #if dTIEGCM:
-              if False:
-#                  # retrieve TIEGCM height-integrated currents:convert to SM 
-#                  # coordinates, set thetas that overlap with MIX to zero, 
-#                  # generate DALECS, calculate deltaB
-#                  x, y, z, dx, dy, dz = pyLTR.transform.SPHtoCAR(
-#                    phi_TIE_mag,
-#                    theta_TIE_mag,
-#                    6500e3,
-#                    dTIEGCM.read('KQPHI', time).T,
-#                    -dTIEGCM.read('KQLAM', time).T,
-#                    0.0 )
-#                                      
-#                  x, y, z = pyLTR.transform.MAGtoSM(x, y, z, time)
-#                  dx, dy, dz = pyLTR.transform.MAGtoSM(dx, dy, dz, time)
-#                  
-#                  (phi_TIE_sm, theta_TIE_sm, rho_TIE_sm,
-#                   Jphi_TIE_sm, Jtheta_TIE_sm, Jrho_TIE_sm) = pyLTR.transform.CARtoSPH(
-#                    x, y, z, dx, dy, dz)
+              if dTIEGCM:
+                  
+                  # retrieve TIEGCM currents in geomagnetic coordinates
+                  Jphi_TIE_geomag = dTIEGCM.read('KQPHI', time).T.copy()
+                  Jtheta_TIE_geomag = -dTIEGCM.read('KQLAM', time).T.copy()
+
+                  # zero-out low and high colatitudes, where we trust MIX more
+                  # FIXME: detect {min,max} MIX thetas, not hardcode {60,120};
+                  #        also, should "blend" MIX and TIEGCM at mid-colats
+                  print("Discarding ", 
+                    (theta_TIE_geomag < (60 * p.pi/180.)).sum() +
+                    (theta_TIE_geomag > (120 * p.pi/180.)).sum(),
+                    " of ", theta_TIE_geomag.size,
+                    "TIEGCM points outside +/- 30 degrees lat.")
+                  Jphi_TIE_geomag[theta_TIE_geomag < (60 * p.pi/180)] = 0
+                  Jphi_TIE_geomag[theta_TIE_geomag > (120 * p.pi/180)] = 0
+                  Jtheta_TIE_geomag[theta_TIE_geomag < (60 * p.pi/180)] = 0
+                  Jtheta_TIE_geomag[theta_TIE_geomag > (120 * p.pi/180)] = 0
+
+                  # generate TIEGCM DALECS (horizontal currents and FAC)
+                  dalecs_T_ion_tmp = dalecs_T_ion.scale(
+                     (Jphi_TIE_geomag, Jtheta_TIE_geomag)
+                  )
+                  rvT_ion = dalecs_T_ion_tmp.rvecs
+                  JvT_ion = dalecs_T_ion_tmp.Jvecs
+                  dvT_ion = dalecs_T_ion_tmp.dvecs
+
+                  dalecs_T_fac_tmp = dalecs_T_fac.scale(
+                     (Jphi_TIE_geomag, Jtheta_TIE_geomag)
+                  )
+                  rvT_fac = dalecs_T_fac_tmp.rvecs
+                  JvT_fac = dalecs_T_fac_tmp.Jvecs
+                  dvT_fac = dalecs_T_fac_tmp.dvecs
 
                   
-                  # retrieve TIEGCM currents in magnetic coordinates
-                  Jphi_TIE_mag = dTIEGCM.read('KQPHI', time).T
-                  Jtheta_TIE_mag = -dTIEGCM.read('KQLAM', time).T
-                  
-                  # generate DALECS from TIEGCM currents in magnetic coordinates
-                  dalecs_T_t = dalecs_T.scale((Jphi_TIE, Jtheta_TIE))
-                  
-                  # trim by colat so that there is no overlap with the MIX grid
-                  # FIXME: this should check to see what the colat range is for
-                  #        the MIX grid, since it changes with model resolution
-                  dalecs_T_ion = dalecs_T_t.trim(rho_min=6500e3,
-                                                 rho_max=6500e3,
-                                                 theta_min=60*p.pi/180.,
-                                                 theta_max=120*p.pi/180.)
-                  rvT_ion = dalecs_T_ion.rvecs
-                  JvT_ion = dalecs_T_ion.Jvecs
-                  dvT_ion = dalecs_T_ion.dvecs
-                  
-                  dalecs_T_fac = dalecs_T_t.trim(rho_min=p.nextafter(6500e3, p.inf),
-                                                 rho_max=2.5*6500e3,
-                                                 theta_min=60*p.pi/180.,
-                                                 theta_max=120*p.pi/180.)
-                  rvT_fac = dalecs_T_fac.rvecs
-                  JvT_fac = dalecs_T_fac.Jvecs
-                  dvT_fac = dalecs_T_fac.dvecs
-                  
-                  # rotate magnetic coordinates into SM before calling bs_sphere()
-                  for i in range(len(rvT_ion[0].flat)):
+                  # rotate magnetic coordinates into SM before calling bs_cart()
+                  for j in range(len(rvT_ion[0].flat)):
+                    
                     # horizontal ionospheric currents
-                    x, y, z, dx, dy, dz = pyLTR.transform.SPHtoCAR(
-                      rvt_ion[0].flat[i],
-                      rvt_ion[1].flat[i],
-                      rvt_ion[2].flat[i],
-                      Jvt_ion[0].flat[i],
-                      Jvt_ion[1].flat[i],
-                      Jvt_ion[2].flat[i]
+                    (rvT_ion[0].flat[j],
+                     rvT_ion[1].flat[j],
+                     rvT_ion[2].flat[j]) = pyLTR.transform.MAGtoSM(
+                       rvT_ion[0].flat[j], 
+                       rvT_ion[1].flat[j],
+                       rvT_ion[2].flat[j],
+                       time
+                    )
+                    (JvT_ion[0].flat[j],
+                     JvT_ion[1].flat[j],
+                     JvT_ion[2].flat[j]) = pyLTR.transform.MAGtoSM(
+                       JvT_ion[0].flat[j], 
+                       JvT_ion[1].flat[j],
+                       JvT_ion[2].flat[j],
+                       time
                     )
                     
-                    x, y, z = pyLTR.transform.MAGtoSM(x, y, z, time)
-                    dx, dy, dz = pyLTR.transform.MAGtoSM(dx, dy, dz, time)
-                    
-                    (rvt_ion[0].flat[i], 
-                     rvt_ion[1].flat[i],
-                     rvt_ion[2].flat[i],
-                     Jvt_ion[0].flat[i],
-                     Jvt_ion[1].flat[i],
-                     Jvt_ion[2].flat[i]) = pyLTR.transform.CARtoSPH(
-                       x, y, z, dx, dy, dz)
-                    
-                    # FACs
-                    x, y, z, dx, dy, dz = pyLTR.transform.SPHtoCAR(
-                      rvt_fac[0].flat[i],
-                      rvt_fac[1].flat[i],
-                      rvt_fac[2].flat[i],
-                      Jvt_fac[0].flat[i],
-                      Jvt_fac[1].flat[i],
-                      Jvt_fac[2].flat[i]
+                    # field-aligned currents
+                    (rvT_fac[0].flat[j],
+                     rvT_fac[1].flat[j],
+                     rvT_fac[2].flat[j]) = pyLTR.transform.MAGtoSM(
+                       rvT_fac[0].flat[j], 
+                       rvT_fac[1].flat[j],
+                       rvT_fac[2].flat[j],
+                       time
                     )
-                    
-                    x, y, z = pyLTR.transform.MAGtoSM(x, y, z, time)
-                    dx, dy, dz = pyLTR.transform.MAGtoSM(dx, dy, dz, time)
-                    
-                    (rvt_fac[0].flat[i], 
-                     rvt_fac[1].flat[i],
-                     rvt_fac[2].flat[i],
-                     Jvt_fac[0].flat[i],
-                     Jvt_fac[1].flat[i],
-                     Jvt_fac[2].flat[i]) = pyLTR.transform.CARtoSPH(
-                       x, y, z, dx, dy, dz)
-                    
-                    
-#                  x, y, z, dx, dy, dz = pyLTR.transform.SPHtoCAR(
-#                    phi_TIE_mag,
-#                    theta_TIE_mag,
-#                    6500e3,
-#                    dTIEGCM.read('KQPHI', time).T,
-#                    -dTIEGCM.read('KQLAM', time).T,
-#                    0.0 )
-#                                      
-#                  x, y, z = pyLTR.transform.MAGtoSM(x, y, z, time)
-#                  dx, dy, dz = pyLTR.transform.MAGtoSM(dx, dy, dz, time)
-#                  
-#                  (phi_TIE_sm, theta_TIE_sm, rho_TIE_sm,
-#                   Jphi_TIE_sm, Jtheta_TIE_sm, Jrho_TIE_sm) = pyLTR.transform.CARtoSPH(
-#                    x, y, z, dx, dy, dz)
+                    (JvT_fac[0].flat[j],
+                     JvT_fac[1].flat[j],
+                     JvT_fac[2].flat[j]) = pyLTR.transform.MAGtoSM(
+                       JvT_fac[0].flat[j], 
+                       JvT_fac[1].flat[j],
+                       JvT_fac[2].flat[j],
+                       time
+                    )
                   
+
+                  # deltaB for TIEGCM horizontal ionospheric currents
+                  (dBxTIE_ion,
+                   dByTIE_ion,
+                   dBzTIE_ion) = DALECS.bs_cart(rvT_ion,
+                                                JvT_ion,
+                                                dvT_ion,
+                                                (obs_x,obs_y,obs_z))
                   
+                  # deltaB for TIEGCM FACs
+                  (dBxTIE_fac,
+                   dByTIE_fac,
+                   dBzTIE_fac) = DALECS.bs_cart(rvT_fac,
+                                                JvT_fac,
+                                                dvT_fac,
+                                                (obs_x,obs_y,obs_z))
                   
-#                  # FIXME: we really need to detect minimum MIX thetas, and
-#                  #        maybe even blend MIX and TIEGCM currents smoothly 
-#                  #        across this boundary
-#                  print("Discarding ", 
-#                    (theta_TIE_sm < (60 * p.pi/180.)).sum() +
-#                    (theta_TIE_sm > (120 * p.pi/180.)).sum(),
-#                    " of ", theta_TIE_sm.size,
-#                    "TIEGCM points outside +/- 30 degrees lat.")
-#                  Jphi_TIE_sm[theta_TIE_sm < (60 * p.pi/180.)] = 0
-#                  Jphi_TIE_sm[theta_TIE_sm > (120 * p.pi/180.)] = 0
-#                  Jtheta_TIE_sm[theta_TIE_sm < (60 * p.pi/180.)] = 0
-#                  Jtheta_TIE_sm[theta_TIE_sm > (120 * p.pi/180.)] = 0
-#                  
-#
-#                  rionTIE_min, rionTIE_max = pyLTR.Physics.DALECS._edgeGrid((phi_TIE_sm, theta_TIE_sm))
-#                  rionTIE_min.append(p.zeros(rho_TIE_sm.shape) + 6500e3)
-#                  rionTIE_max.append(p.zeros(rho_TIE_sm.shape) + p.Inf)
-#                  
-#                  # ionospheric currents only
-#                  (rvTIE_ion,
-#                   JvTIE_ion,
-#                   dvTIE_ion) = pyLTR.Physics.DALECS.dalecs_sphere(
-#                    [rionTIE_min[0], rionTIE_min[1], rionTIE_min[2]],
-#                    [rionTIE_max[0], rionTIE_max[1], rionTIE_min[2]],
-#                    (Jphi_TIE_sm, Jtheta_TIE_sm),
-#                    10, False)
-#                  
-#                  
-                  # deltaB for TIEGCM ionospheric currents in SM coordinates
-                  (dBphiTIE_ion,
-                   dBthetaTIE_ion,
-                   dBrhoTIE_ion) = pyLTR.Physics.BS.bs_sphere(
-                    rvTIE_ion,
-                    JvTIE_ion,
-                    dvTIE_ion,
-                    (obs_phi, obs_theta, obs_rho))
-                  
-                  # deltaB for TIEGCM FACs in SM coordinates
-                  (dBphiTIE_fac,
-                   dBthetaTIE_fac,
-                   dBrhoTIE_fac) = pyLTR.Physics.BS.bs_sphere(
-                    rvTIE_fac,
-                    JvTIE_fac,
-                    dvTIE_fac,
-                    (obs_phi, obs_theta, obs_rho))
-                                      
+                  dBxTIE_fac = dBxTIE_fac * 0
+                  dByTIE_fac = dByTIE_fac * 0
+                  dBzTIE_fac = dBzTIE_fac * 0
+
               else:
                   
                   # set dBs to zero if no TIEGCM data is available
-                  dBphiTIE_ion = p.zeros(p.array(obs_phi).shape)
-                  dBthetaTIE_ion = p.zeros(p.array(obs_theta).shape)
-                  dBrhoTIE_ion = p.zeros(p.array(obs_rho).shape)
-                  dBphiTIE_fac = p.zeros(p.array(obs_phi).shape)
-                  dBthetaTIE_fac = p.zeros(p.array(obs_theta).shape)
-                  dBrhoTIE_fac = p.zeros(p.array(obs_rho).shape)
-
+                  dBxTIE_ion = p.zeros(p.array(obs_x).shape)
+                  dByTIE_ion = p.zeros(p.array(obs_y).shape)
+                  dBzTIE_ion = p.zeros(p.array(obs_z).shape)
+                  dBxTIE_fac = p.zeros(p.array(obs_x).shape)
+                  dByTIE_fac = p.zeros(p.array(obs_y).shape)
+                  dBzTIE_fac = p.zeros(p.array(obs_z).shape)
 
 
               if dLFM:
@@ -1169,93 +973,98 @@ def extractQuantities(path='./', run='',
                   BzM = dLFM.read('bz_', trLFM[index0:index1][i]) # this is in G
                   JxM, JyM, JzM = pyLTR.Physics.LFMCurrent(
                     hgridcc, BxM, ByM, BzM, rion=1) # ...should be A/m^2 given default input units
-
-                  (phiM, thetaM, rhoM,
-                   JphiM, JthetaM, JrhoM) = pyLTR.transform.CARtoSPH(
-                    xJM, yJM, zJM, JxM, JyM, JzM)
                   
-                  (dBphi_mag,
-                   dBtheta_mag,
-                   dBrho_mag) = pyLTR.Physics.BS.bs_sphere(
-                    (phiM,thetaM,rhoM),
-                    (JphiM,JthetaM,JrhoM),
-                    dVM,
-                    (obs_phi,obs_theta,obs_rho))
-                    
+                  (dBx_mag,
+                   dBy_mag,
+                   dBz_mag) = DALECS.bs_cart(
+                      (xJM, yJM, zJM),
+                      (JxM, JyM, JzM),
+                      dVM,
+                      (obs_x,obs_y,obs_z)
+                   )
               else:
                   
                   # set dBs to zero if no LFM data is available
-                  dBphi_mag = p.zeros(p.array(obs_phi).shape)
-                  dBtheta_mag = p.zeros(p.array(obs_theta).shape)
-                  dBrho_mag = p.zeros(p.array(obs_rho).shape)
-                  
-
-
-
+                  dBx_mag = p.zeros(p.array(obs_phi).shape)
+                  dBy_mag = p.zeros(p.array(obs_theta).shape)
+                  dBz_mag = p.zeros(p.array(obs_rho).shape)
 
 
               if geoGrid:
 
                  # rotate north ionospheric contribution from SM to GEO coordinates;
                  # leave position vectors unchanged for subsequent rotations
-                 x,y,z,dx,dy,dz = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho,
-                                                           dBphiN_ion, dBthetaN_ion, dBrhoN_ion)
-                 x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-                 dx,dy,dz = pyLTR.transform.SMtoGEO(dx,dy,dz,time)
-                 _, _, _, dBphiN_ion, dBthetaN_ion, dBrhoN_ion = pyLTR.transform.CARtoSPH(x,y,z,dx,dy,dz)
+                 x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+                 dx, dy, dz = pyLTR.transform.SMtoGEO(
+                    dBxN_ion, dByN_ion, dBzN_ion, time
+                 )
+                 _, _, _, dBphiN_ion, dBthetaN_ion, dBrhoN_ion = pyLTR.transform.CARtoSPH(
+                     x, y, z, dx, dy, dz
+                 )
 
                  # rotate north FAC contribution from SM to GEO coordinates;
                  # leave position vectors unchanged for subsequent rotations
-                 x,y,z,dx,dy,dz = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho,
-                                                           dBphiN_fac, dBthetaN_fac, dBrhoN_fac)
-                 x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-                 dx,dy,dz = pyLTR.transform.SMtoGEO(dx,dy,dz,time)
-                 _, _, _, dBphiN_fac, dBthetaN_fac, dBrhoN_fac = pyLTR.transform.CARtoSPH(x,y,z,dx,dy,dz)
+                 x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+                 dx, dy, dz = pyLTR.transform.SMtoGEO(
+                    dBxN_fac, dByN_fac, dBzN_fac, time
+                 )
+                 _, _, _, dBphiN_fac, dBthetaN_fac, dBrhoN_fac = pyLTR.transform.CARtoSPH(
+                    x, y, z, dx, dy, dz
+                 )
 
 
                  # rotate south ionospheric contribution from SM to GEO coordinates;
                  # leave position vectors unchanged for subsequent rotations
-                 x,y,z,dx,dy,dz = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho,
-                                                           dBphiS_ion, dBthetaS_ion, dBrhoS_ion)
-                 x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-                 dx,dy,dz = pyLTR.transform.SMtoGEO(dx,dy,dz,time)
-                 _, _, _, dBphiS_ion, dBthetaS_ion, dBrhoS_ion = pyLTR.transform.CARtoSPH(x,y,z,dx,dy,dz)
+                 x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+                 dx, dy, dz = pyLTR.transform.SMtoGEO(
+                    dBxS_ion, dByS_ion, dBzS_ion, time
+                 )
+                 _, _, _, dBphiS_ion, dBthetaS_ion, dBrhoS_ion = pyLTR.transform.CARtoSPH(
+                    x, y, z, dx, dy, dz
+                 )
 
                  # rotate south FAC contribution from SM to GEO coordinates;
                  # leave position vectors unchanged for subsequent rotations
-                 x,y,z,dx,dy,dz = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho,
-                                                           dBphiS_fac, dBthetaS_fac, dBrhoS_fac)
-                 x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-                 dx,dy,dz = pyLTR.transform.SMtoGEO(dx,dy,dz,time)
-                 _, _, _, dBphiS_fac, dBthetaS_fac, dBrhoS_fac = pyLTR.transform.CARtoSPH(x,y,z,dx,dy,dz)
+                 x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+                 dx, dy, dz = pyLTR.transform.SMtoGEO(
+                    dBxS_fac, dByS_fac, dBzS_fac, time
+                 )
+                 _, _, _, dBphiS_fac, dBthetaS_fac, dBrhoS_fac = pyLTR.transform.CARtoSPH(
+                    x, y, z, dx, dy, dz
+                 )
 
 
-                     
                  # rotate TIEGCM ionospheric contribution from SM to GEO coordinates;
                  # leave position vectors unchanged for subsequent rotations
-                 x,y,z,dx,dy,dz = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho,
-                                                           dBphiTIE_ion, dBthetaTIE_ion, dBrhoTIE_ion)
-                 x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-                 dx,dy,dz = pyLTR.transform.SMtoGEO(dx,dy,dz,time)
-                 _, _, _, dBphiTIE_ion, dBthetaTIE_ion, dBrhoTIE_ion = pyLTR.transform.CARtoSPH(x,y,z,dx,dy,dz)
+                 x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+                 dx, dy, dz = pyLTR.transform.SMtoGEO(
+                    dBxTIE_ion, dByTIE_ion, dBzTIE_ion, time
+                 )
+                 _, _, _, dBphiTIE_ion, dBthetaTIE_ion, dBrhoTIE_ion = pyLTR.transform.CARtoSPH(
+                    x, y, z, dx, dy, dz
+                 )
 
                  # rotate TIEGCM FAC contribution from SM to GEO coordinates;
                  # leave position vectors unchanged for subsequent rotations
-                 x,y,z,dx,dy,dz = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho,
-                                                           dBphiTIE_fac, dBthetaTIE_fac, dBrhoTIE_fac)
-                 x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-                 dx,dy,dz = pyLTR.transform.SMtoGEO(dx,dy,dz,time)
-                 _, _, _, dBphiTIE_fac, dBthetaTIE_fac, dBrhoTIE_fac = pyLTR.transform.CARtoSPH(x,y,z,dx,dy,dz)
-                                        
+                 x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+                 dx, dy, dz = pyLTR.transform.SMtoGEO(
+                    dBxTIE_fac, dByTIE_fac, dBzTIE_fac, time
+                 )
+                 _, _, _, dBphiTIE_fac, dBthetaTIE_fac, dBrhoTIE_fac = pyLTR.transform.CARtoSPH(
+                    x, y, z, dx, dy, dz
+                 )
 
 
                  # rotate magnetospheric contribution from SM to GEO coordinates; leave
                  # position vectors unchanged for subsequent rotations
-                 x,y,z,dx,dy,dz = pyLTR.transform.SPHtoCAR(obs_phi, obs_theta, obs_rho,
-                                                           dBphi_mag, dBtheta_mag, dBrho_mag)
-                 x,y,z = pyLTR.transform.SMtoGEO(x,y,z,time)
-                 dx,dy,dz = pyLTR.transform.SMtoGEO(dx,dy,dz,time)
-                 _, _, _, dBphi_mag, dBtheta_mag, dBrho_mag = pyLTR.transform.CARtoSPH(x,y,z,dx,dy,dz)
+                 x, y, z = pyLTR.transform.SMtoGEO(obs_x, obs_y, obs_z, time)
+                 dx, dy, dz = pyLTR.transform.SMtoGEO(
+                    dBx_mag, dBy_mag, dBz_mag, time
+                 )
+                 _, _, _, dBphi_mag, dBtheta_mag, dBrho_mag = pyLTR.transform.CARtoSPH(
+                    x, y, z, dx, dy, dz
+                 )
+
                     
 
               

--- a/pyLTR/transform/transforms.py
+++ b/pyLTR/transform/transforms.py
@@ -58,7 +58,8 @@ def SPHtoCAR(phi,theta,rho,dphi=None,dtheta=None,drho=None):
          ##        to accept array inputs, if speed is an issue. -EJR 10/2013
          ##
          #output = pyLTR.transform.geopack_08.sphcar_08(rho,theta,phi,0.,0.,0., iSPHtoCAR)
-         v_gp08 = p.vectorize(pyLTR.transform.geopack_08.sphcar_08)
+         v_gp08 = p.vectorize(pyLTR.transform.geopack_08.sphcar_08,
+                        otypes=[float]*7)
          output = v_gp08(rho,theta,phi, 0.,0.,0., iSPHtoCAR)
          
          ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -81,11 +82,13 @@ def SPHtoCAR(phi,theta,rho,dphi=None,dtheta=None,drho=None):
       ##
       
       #output = pyLTR.transform.geopack_08.sphcar_08(rho,theta,phi,0.,0.,0., iSPHtoCAR)
-      v_gp08a = p.vectorize(pyLTR.transform.geopack_08.sphcar_08)
+      v_gp08a = p.vectorize(pyLTR.transform.geopack_08.sphcar_08,
+                        otypes=[float]*7)
       _,_,_,x,y,z,_ = v_gp08a(rho,theta,phi, 0.,0.,0., iSPHtoCAR)
       
       #dx,dy,dz = pyLTR.transform.geopack_08.bspcar_08(theta,phi,drho,dtheta,dphi)
-      v_gp08b = p.vectorize(pyLTR.transform.geopack_08.bspcar_08)
+      v_gp08b = p.vectorize(pyLTR.transform.geopack_08.bspcar_08,
+                        otypes=[float]*3)
       dx,dy,dz = v_gp08b(theta,phi, drho,dtheta,dphi)
       
       ## if all scalar inputs, return scalar outputs, otherwise ndarrays -EJR 10/2013
@@ -118,7 +121,8 @@ def CARtoSPH(x,y,z,dx=None,dy=None,dz=None):
          ##        to accept array inputs, if speed is an issue. -EJR 10/2013
          ##
          #output = pyLTR.transform.geopack_08.sphcar_08(0.,0.,0.,x,y,z, iSPHtoCAR)
-         v_gp08 = p.vectorize(pyLTR.transform.geopack_08.sphcar_08)
+         v_gp08 = p.vectorize(pyLTR.transform.geopack_08.sphcar_08,
+                        otypes=[float]*7)
          output = v_gp08(0.,0.,0.,x,y,z, iSPHtoCAR)
          
          ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -141,11 +145,13 @@ def CARtoSPH(x,y,z,dx=None,dy=None,dz=None):
       ##
       
       #output = pyLTR.transform.geopack_08.sphcar_08(0.,0.,0.,x,y,z, iSPHtoCAR)
-      v_gp08a = p.vectorize(pyLTR.transform.geopack_08.sphcar_08)
+      v_gp08a = p.vectorize(pyLTR.transform.geopack_08.sphcar_08,
+                        otypes=[float]*7)
       rho,theta,phi,_,_,_,_ = v_gp08a(0.,0.,0.,x,y,z, iSPHtoCAR)
       
       #dx,dy,dz = pyLTR.transform.geopack_08.bspcar_08(theta,phi,drho,dtheta,dphi)
-      v_gp08b = p.vectorize(pyLTR.transform.geopack_08.bcarsp_08)
+      v_gp08b = p.vectorize(pyLTR.transform.geopack_08.bcarsp_08,
+                        otypes=[float]*3)
       drho,dtheta,dphi = v_gp08b(x,y,z,dx,dy,dz)
       
       ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -184,7 +190,8 @@ def SMtoGSM(x,y,z, dateTime):
         ##        to accept array inputs, if speed is an issue. -EJR 10/2013
         ##
         #output = pyLTR.transform.geopack_08.smgsw_08(x,y,z, 0.,0.,0., iSMtoGSM)
-        v_gp08 = p.vectorize(pyLTR.transform.geopack_08.smgsw_08)
+        v_gp08 = p.vectorize(pyLTR.transform.geopack_08.smgsw_08,
+                        otypes=[float]*6)
         output = v_gp08(x,y,z, 0.,0.,0., iSMtoGSM)
         
         ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -223,7 +230,8 @@ def GSMtoSM(x,y,z, dateTime):
         ##        to accept array inputs, if speed is an issue. -EJR 10/2013
         ##
         #output = pyLTR.transform.geopack_08.smgsw_08(0.,0.,0., x, y, z, iSMtoGSM)
-        v_gp08 = p.vectorize(pyLTR.transform.geopack_08.smgsw_08)
+        v_gp08 = p.vectorize(pyLTR.transform.geopack_08.smgsw_08,
+                        otypes=[float]*6)
         output = v_gp08(0., 0., 0., x, y, z, iSMtoGSM)
         
         ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -261,7 +269,8 @@ def GSEtoGSM(x,y,z, dateTime):
         ##        to accept array inputs, if speed is an issue. -EJR 10/2013
         ##
         #output = pyLTR.transform.geopack_08.gswgse_08(0.,0.,0., x,y,z, iGSEtoGSM)
-        v_gp08 = p.vectorize(pyLTR.transform.geopack_08.gswgse_08)
+        v_gp08 = p.vectorize(pyLTR.transform.geopack_08.gswgse_08,
+                        otypes=[float]*7)
         output = v_gp08(0., 0., 0., x, y, z, iGSEtoGSM)
         
         ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -301,7 +310,8 @@ def GEOtoMAG(x,y,z, dateTime):
     ##        to accept array inputs, if speed is an issue. -EJR 10/2013
     ##
     #output = pyLTR.transform.geopack_08.gswgse_08(x, y, z, 0.,0.,0., iGEOtoMAG)
-    v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geomag_08)
+    v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geomag_08,
+                        otypes=[float]*6)
     output = v_gp08(x, y, z, 0., 0., 0., iGEOtoMAG)
      
     ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -328,7 +338,8 @@ def MAGtoGEO(x,y,z, dateTime):
     ##        to accept array inputs, if speed is an issue. -EJR 10/2013
     ##
     #output = pyLTR.transform.geopack_08.gswgse_08(0.,0.,0., x, y, z, iGEOtoMAG)
-    v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geomag_08)
+    v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geomag_08,
+                        otypes=[float]*6)
     output = v_gp08(0., 0., 0., x, y, z, iGEOtoMAG)
      
     ## if scalar inputs, generate scalar outputs -EJR 10/2013
@@ -353,7 +364,8 @@ def SMtoMAG(x,y,z, dateTime):
    ##        to accept array inputs, if speed is an issue. -EJR 12/2013
    ##
    
-   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.magsm_08)
+   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.magsm_08,
+                        otypes=[float]*6)
    output =  v_gp08(0., 0., 0., x, y, z, iSMtoMAG)
    
    ## if scalar inputs, generate scalar outputs -EJR 12/2013
@@ -377,7 +389,8 @@ def MAGtoSM(x,y,z, dateTime):
    ##        optimized...Geopack should be ported to Python, or re-written
    ##        to accept array inputs, if speed is an issue. -EJR 12/2013
    ##
-   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.magsm_08)
+   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.magsm_08,
+                        otypes=[float]*6)
    output =  v_gp08(x, y, z, 0., 0., 0., iMAGtoSM)
    
    ## if scalar inputs, generate scalar outputs -EJR 12/2013
@@ -402,7 +415,8 @@ def GEOtoGSM(x,y,z, dateTime):
    ##        optimized...Geopack should be ported to Python, or re-written
    ##        to accept array inputs, if speed is an issue. -EJR 12/2013
    ##
-   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geogsw_08)
+   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geogsw_08,
+                        otypes=[float]*6)
    output =  v_gp08(x, y, z, 0., 0., 0., iGEOtoGSM)
    
    ## if scalar inputs, generate scalar outputs -EJR 12/2013
@@ -426,7 +440,8 @@ def GSMtoGEO(x,y,z, dateTime):
    ##        optimized...Geopack should be ported to Python, or re-written
    ##        to accept array inputs, if speed is an issue. -EJR 12/2013
    ##
-   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geogsw_08)
+   v_gp08 = p.vectorize(pyLTR.transform.geopack_08.geogsw_08,
+                        otypes=[float]*6)
    output =  v_gp08(0., 0., 0., x, y, z, iGEOtoGSM)
    
    ## if scalar inputs, generate scalar outputs -EJR 12/2013
@@ -452,10 +467,12 @@ def GEOtoSM(x,y,z, dateTime):
    ##        optimized...Geopack should be ported to Python, or re-written
    ##        to accept array inputs, if speed is an issue. -EJR 12/2013
    ##
-   v_gp08a = p.vectorize(pyLTR.transform.geopack_08.geogsw_08)
+   v_gp08a = p.vectorize(pyLTR.transform.geopack_08.geogsw_08,
+                        otypes=[float]*6)
    _,_,_,xgsm,ygsm,zgsm =  v_gp08a(x, y, z, 0., 0., 0., iGEOtoGSM)
    
-   v_gp08b = p.vectorize(pyLTR.transform.geopack_08.smgsw_08)
+   v_gp08b = p.vectorize(pyLTR.transform.geopack_08.smgsw_08,
+                        otypes=[float]*6)
    xsm,ysm,zsm,_,_,_ =  v_gp08b(0., 0., 0., xgsm, ygsm, zgsm, iGSMtoSM)
    
    
@@ -481,10 +498,12 @@ def SMtoGEO(x,y,z, dateTime):
    ##        optimized...Geopack should be ported to Python, or re-written
    ##        to accept array inputs, if speed is an issue. -EJR 12/2013
    ##
-   v_gp08a = p.vectorize(pyLTR.transform.geopack_08.smgsw_08)
+   v_gp08a = p.vectorize(pyLTR.transform.geopack_08.smgsw_08,
+                        otypes=[float]*6)
    _,_,_,xgsm,ygsm,zgsm =  v_gp08a(x, y, z, 0., 0., 0., iSMtoGSM)
    
-   v_gp08b = p.vectorize(pyLTR.transform.geopack_08.geogsw_08)
+   v_gp08b = p.vectorize(pyLTR.transform.geopack_08.geogsw_08,
+                        otypes=[float]*6)
    xgeo,ygeo,zgeo,_,_,_ =  v_gp08b(0., 0., 0., xgsm, ygsm, zgsm, iGSMtoGEO)
    
    


### PR DESCRIPTION
Lots of internal changes, but the most impactful visible change is that the DALECS class now separates ionospheric, field-aligned, and equatorial currents. This has (temporarily) slowed things down, but makes customizing DALECS much easier than relying on `_trim_phi_theta_rho()`, which had trouble when finite machine precision prevented clean separation for the different current segments (e.g., imagine an equatorial DALEC).