### PR TITLE
Update deltaBTimeSeries for BS matrix

### DIFF
--- a/examples/deltaB_IPyParallel.ipynb
+++ b/examples/deltaB_IPyParallel.ipynb
@@ -10,12 +10,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "# this SHOULD work inside JupyterLab if the Python environment is correct\n",
-    "#%matplotlib widget\n",
+    "#%matplhttp://localhost:8889/notebooks/examples/deltaB_IPyParallel.ipynb#otlib widget\n",
     "\n",
     "# this does NOT work inside JupyterLab, but DOES in a Notebook (less insecure)\n",
     "%matplotlib notebook\n",
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +149,7 @@
     "\n",
     "# start time and endtime for processing\n",
     "t0 = datetime.datetime(2015,3,17,6,0,0)\n",
-    "t1 = datetime.datetime(2015,3,17,6,5,0)\n",
+    "t1 = datetime.datetime(2015,3,17,6,9,0)\n",
     "\n",
     "# output folder (this must be relative to path)\n",
     "#outPath = \"../../../jrigler/LTR/13SPB/output/\"\n",
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 33,
    "metadata": {
     "scrolled": true
    },
@@ -385,59 +385,95 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracting quantities for 5 time steps.\n",
+      "MIX files missing or ignored; continuing anyway...\n",
+      "Extracting quantities for 10 time steps.\n",
       "Likely not a run from terminal so no progress bar\n",
+      "\n",
+      "Pre-compute TIEGCM DALECS\n",
+      "ionospheric currents\n",
       "Initializing  7760  type1 Bostrom loops\n",
       "Initializing  7760  type2 Bostrom loops\n",
-      "9.542297121952288 Generating TIEGCM ION DALECS\n",
+      "field-aligned currents\n",
       "Initializing  7760  type1 Bostrom loops\n",
       "Initializing  7760  type2 Bostrom loops\n",
-      "21.23489470896311 Generating TIEGCM FAC DALECS\n",
-      "22.990315126022324 Trimming TIEGCM FAC DALECS\n",
+      "...done after 26.374226 seconds\n",
+      "\n",
+      "Pre-compute LFM grid and volumes\n",
+      "...done after 0.197943 seconds\n",
+      "\n",
+      "Starting main loop\n",
       "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-00-00Z...\n",
       "\n",
       "TIEGCM\n",
       "Calculating BS matrices\n",
       "Calculating BS matrices\n",
-      "...done after 156.162561 seconds\n",
+      "...done after 151.429494 seconds\n",
       "\n",
       "LFM\n",
-      "...done after 1.113212 seconds\n",
+      "...done after 1.088976 seconds\n",
       "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-01-00Z...\n",
       "\n",
       "TIEGCM\n",
-      "...done after 0.001528 seconds\n",
+      "...done after 0.001659 seconds\n",
       "\n",
       "LFM\n",
-      "...done after 1.069477 seconds\n",
+      "...done after 1.060553 seconds\n",
       "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-02-00Z...\n",
       "\n",
       "TIEGCM\n",
-      "...done after 0.002267 seconds\n",
+      "...done after 0.001806 seconds\n",
       "\n",
       "LFM\n",
-      "...done after 1.289377 seconds\n",
+      "...done after 1.103824 seconds\n",
       "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-03-00Z...\n",
       "\n",
       "TIEGCM\n",
-      "...done after 0.002142 seconds\n",
+      "...done after 0.001611 seconds\n",
       "\n",
       "LFM\n",
-      "...done after 1.398556 seconds\n",
+      "...done after 1.080433 seconds\n",
       "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-04-00Z...\n",
       "\n",
       "TIEGCM\n",
-      "...done after 0.001603 seconds\n",
+      "...done after 0.001552 seconds\n",
       "\n",
       "LFM\n",
-      "...done after 1.175004 seconds\n",
+      "...done after 1.066303 seconds\n",
       "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-05-00Z...\n",
       "\n",
       "TIEGCM\n",
-      "...done after 0.001883 seconds\n",
+      "...done after 0.001525 seconds\n",
       "\n",
       "LFM\n",
-      "...done after 1.410851 seconds\n"
+      "...done after 1.087546 seconds\n",
+      "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-06-00Z...\n",
+      "\n",
+      "TIEGCM\n",
+      "...done after 0.001621 seconds\n",
+      "\n",
+      "LFM\n",
+      "...done after 1.076919 seconds\n",
+      "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-07-00Z...\n",
+      "\n",
+      "TIEGCM\n",
+      "...done after 0.001519 seconds\n",
+      "\n",
+      "LFM\n",
+      "...done after 1.080311 seconds\n",
+      "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-08-00Z...\n",
+      "\n",
+      "TIEGCM\n",
+      "...done after 0.001771 seconds\n",
+      "\n",
+      "LFM\n",
+      "...done after 1.076540 seconds\n",
+      "No valid binary file found, recalculating obs_deltaB_2015-03-17T06-09-00Z...\n",
+      "\n",
+      "TIEGCM\n",
+      "...done after 0.001535 seconds\n",
+      "\n",
+      "LFM\n",
+      "...done after 1.060612 seconds\n"
      ]
     }
    ],
@@ -452,6 +488,12 @@
     "    't1':t1,\n",
     "    'obsList':obsList,\n",
     "    'geoGrid':True,\n",
+    "#     'smGrid':False,  # fix so that smGrid is default ONLY if nothing else is set\n",
+    "    'mix':False,\n",
+    "    'tie':True,\n",
+    "    'lfm':True,\n",
+    "    'mix_bs_mx':True,\n",
+    "    'tie_bs_mx':True,\n",
     "    'ignoreBinary':False,\n",
     "    'binaryType':'pkl',\n",
     "    'outDirName':outPath + '/obs'\n",
@@ -460,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 26,
    "metadata": {
     "scrolled": false
    },
@@ -1248,7 +1290,7 @@
     {
      "data": {
       "text/html": [
-       "<div id='1d9af7d3-b162-4b7d-aea6-733df267bf1f'></div>"
+       "<div id='6140e6c0-2026-4fc0-b7f4-5dc77b386f32'></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1256,18 +1298,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/erigler/anaconda3/envs/py36/lib/python3.6/site-packages/pandas/plotting/_matplotlib/converter.py:103: FutureWarning: Using an implicitly registered datetime converter for a matplotlib plotting method. The converter was registered by pandas on import. Future versions of pandas will require you to explicitly register matplotlib converters.\n",
-      "\n",
-      "To register the converters:\n",
-      "\t>>> from pandas.plotting import register_matplotlib_converters\n",
-      "\t>>> register_matplotlib_converters()\n",
-      "  warnings.warn(msg, FutureWarning)\n"
-     ]
     }
    ],
    "source": [


### PR DESCRIPTION
Previously, deltaBTimeSeries.py was not using DALECS' BS matrix
acceleration correctly, at least in GEO coordinates, because the
obs locations would change with each time step. This update is
a major overhaul in the logic of the extractQuantities() method
whereby all DALECS (and associated BS calculations) are created
in the coordinate frame specified by the user. This requires
interpolation of input currents, and thus some loss of accuracy,
but as long as the input ionospheric grids are of a reasonable
resolution, this is minimal. On the up-side, it is now possible
to request output on a geomagnetic grid, not just geographic and
solar magnetic.

This update also included several new keyword arguments to give
the user more control over which inputs are read in, which BS
integration method is used, and what obs grid coordinates are
used. I also cleaned up the command line interface a bit, and
fixed some small problems with related time series plot
generation.

The initial step of a loop that uses the BS matrix method is
still quite slow, but there is probably a fix to address much
of this slowness.